### PR TITLE
speed up adjacency matrix computation

### DIFF
--- a/Tests/example 1.ipynb
+++ b/Tests/example 1.ipynb
@@ -1,0 +1,185 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "04da6bff",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\Yasaman\\temporal-networks\n"
+     ]
+    }
+   ],
+   "source": [
+    "cd .."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "521c3a03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.tempnet import temporal_network as tn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9e42e943",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source_nodes=[0, 1, 1]\n",
+    "target_nodes=[1, 2, 3]\n",
+    "starting_times=[0, 1, 2]\n",
+    "ending_times=[2.5, 2.5, 2.5]\n",
+    "cont_net=tn.ContTempNetwork(source_nodes=source_nodes, target_nodes=target_nodes, starting_times=starting_times, ending_times=ending_times)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ed54fdc1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'src.tempnet.temporal_network.ContTempNetwork'> with 4 nodes and 3 events\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(cont_net)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "49267ec4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>source_nodes</th>\n",
+       "      <th>target_nodes</th>\n",
+       "      <th>starting_times</th>\n",
+       "      <th>ending_times</th>\n",
+       "      <th>durations</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2.5</td>\n",
+       "      <td>2.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2.5</td>\n",
+       "      <td>1.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2.5</td>\n",
+       "      <td>0.5</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   source_nodes  target_nodes  starting_times  ending_times  durations\n",
+       "0             0             1               0           2.5        2.5\n",
+       "1             1             2               1           2.5        1.5\n",
+       "2             1             3               2           2.5        0.5"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cont_net.events_table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "41662be4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cont_net.num_nodes"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/Tests/example 2.ipynb
+++ b/Tests/example 2.ipynb
@@ -426,7 +426,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 29,
    "id": "708bcb93",
    "metadata": {},
    "outputs": [],
@@ -434,12 +434,12 @@
     "url = 'https://zenodo.org/record/4725155/files/'\\\n",
     "                        'mice_contact_sequence.csv.gz'\n",
     "cut_after = 24*3600 # only use first day\n",
-    "source_nodes, target_nodes,starting_times, ending_times=load_network_from_csv(url, cut_after)"
+    "source_nodes, target_nodes,starting_times, ending_times=load_network_from_csv(url, cut_after=None)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 30,
    "id": "1bd1071f",
    "metadata": {},
    "outputs": [],
@@ -454,7 +454,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 31,
    "id": "8d569119",
    "metadata": {},
    "outputs": [
@@ -462,7 +462,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<class 'src.tempnet.temporal_network.ContTempNetwork'> with 414 nodes and 132034 events\n"
+      "<class 'src.tempnet.temporal_network.ContTempNetwork'> with 437 nodes and 5751692 events\n"
      ]
     }
    ],
@@ -472,7 +472,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 32,
    "id": "51f159fd",
    "metadata": {},
    "outputs": [
@@ -480,7 +480,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "256 ms ± 10.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "14 s ± 2.62 s per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -490,7 +490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 33,
    "id": "cdbd9a20",
    "metadata": {},
    "outputs": [
@@ -498,7 +498,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "19.9 ms ± 651 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "1.04 s ± 225 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],

--- a/Tests/example 2.ipynb
+++ b/Tests/example 2.ipynb
@@ -1,0 +1,531 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9e42e943",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\Yasaman\\temporal-networks\n"
+     ]
+    }
+   ],
+   "source": [
+    "cd .."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6e2318e9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "A module that was compiled using NumPy 1.x cannot be run in\n",
+      "NumPy 2.4.3 as it may crash. To support both 1.x and 2.x\n",
+      "versions of NumPy, modules must be compiled with NumPy 2.0.\n",
+      "Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.\n",
+      "\n",
+      "If you are a user of the module, the easiest solution will be to\n",
+      "downgrade to 'numpy<2' or try to upgrade the affected module.\n",
+      "We expect that some modules will need time to support NumPy 2.\n",
+      "\n",
+      "Traceback (most recent call last):  File \"<frozen runpy>\", line 198, in _run_module_as_main\n",
+      "  File \"<frozen runpy>\", line 88, in _run_code\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel_launcher.py\", line 18, in <module>\n",
+      "    app.launch_new_instance()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\traitlets\\config\\application.py\", line 1075, in launch_instance\n",
+      "    app.start()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\kernelapp.py\", line 739, in start\n",
+      "    self.io_loop.start()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\tornado\\platform\\asyncio.py\", line 205, in start\n",
+      "    self.asyncio_loop.run_forever()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\asyncio\\base_events.py\", line 608, in run_forever\n",
+      "    self._run_once()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\asyncio\\base_events.py\", line 1936, in _run_once\n",
+      "    handle._run()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\asyncio\\events.py\", line 84, in _run\n",
+      "    self._context.run(self._callback, *self._args)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\kernelbase.py\", line 545, in dispatch_queue\n",
+      "    await self.process_one()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\kernelbase.py\", line 534, in process_one\n",
+      "    await dispatch(*args)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\kernelbase.py\", line 437, in dispatch_shell\n",
+      "    await result\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\ipkernel.py\", line 362, in execute_request\n",
+      "    await super().execute_request(stream, ident, parent)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\kernelbase.py\", line 778, in execute_request\n",
+      "    reply_content = await reply_content\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\ipkernel.py\", line 449, in do_execute\n",
+      "    res = shell.run_cell(\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\zmqshell.py\", line 549, in run_cell\n",
+      "    return super().run_cell(*args, **kwargs)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\interactiveshell.py\", line 3075, in run_cell\n",
+      "    result = self._run_cell(\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\interactiveshell.py\", line 3130, in _run_cell\n",
+      "    result = runner(coro)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\async_helpers.py\", line 128, in _pseudo_sync_runner\n",
+      "    coro.send(None)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\interactiveshell.py\", line 3334, in run_cell_async\n",
+      "    has_raised = await self.run_ast_nodes(code_ast.body, cell_name,\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\interactiveshell.py\", line 3517, in run_ast_nodes\n",
+      "    if await self.run_code(code, result, async_=asy):\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\interactiveshell.py\", line 3577, in run_code\n",
+      "    exec(code_obj, self.user_global_ns, self.user_ns)\n",
+      "  File \"C:\\Users\\Yasaman\\AppData\\Local\\Temp\\ipykernel_36504\\2658778630.py\", line 1, in <module>\n",
+      "    from src.tempnet import temporal_network as tn\n",
+      "  File \"c:\\Users\\Yasaman\\temporal-networks\\src\\tempnet\\temporal_network.py\", line 30, in <module>\n",
+      "    import pandas as pd\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\__init__.py\", line 38, in <module>\n",
+      "    from pandas.compat import (\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\compat\\__init__.py\", line 29, in <module>\n",
+      "    from pandas.compat.pyarrow import (\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\compat\\pyarrow.py\", line 8, in <module>\n",
+      "    import pyarrow as pa\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pyarrow\\__init__.py\", line 65, in <module>\n",
+      "    import pyarrow.lib as _lib\n"
+     ]
+    },
+    {
+     "ename": "AttributeError",
+     "evalue": "_ARRAY_API not found",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[1;31mAttributeError\u001b[0m: _ARRAY_API not found"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "A module that was compiled using NumPy 1.x cannot be run in\n",
+      "NumPy 2.4.3 as it may crash. To support both 1.x and 2.x\n",
+      "versions of NumPy, modules must be compiled with NumPy 2.0.\n",
+      "Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.\n",
+      "\n",
+      "If you are a user of the module, the easiest solution will be to\n",
+      "downgrade to 'numpy<2' or try to upgrade the affected module.\n",
+      "We expect that some modules will need time to support NumPy 2.\n",
+      "\n",
+      "Traceback (most recent call last):  File \"<frozen runpy>\", line 198, in _run_module_as_main\n",
+      "  File \"<frozen runpy>\", line 88, in _run_code\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel_launcher.py\", line 18, in <module>\n",
+      "    app.launch_new_instance()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\traitlets\\config\\application.py\", line 1075, in launch_instance\n",
+      "    app.start()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\kernelapp.py\", line 739, in start\n",
+      "    self.io_loop.start()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\tornado\\platform\\asyncio.py\", line 205, in start\n",
+      "    self.asyncio_loop.run_forever()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\asyncio\\base_events.py\", line 608, in run_forever\n",
+      "    self._run_once()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\asyncio\\base_events.py\", line 1936, in _run_once\n",
+      "    handle._run()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\asyncio\\events.py\", line 84, in _run\n",
+      "    self._context.run(self._callback, *self._args)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\kernelbase.py\", line 545, in dispatch_queue\n",
+      "    await self.process_one()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\kernelbase.py\", line 534, in process_one\n",
+      "    await dispatch(*args)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\kernelbase.py\", line 437, in dispatch_shell\n",
+      "    await result\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\ipkernel.py\", line 362, in execute_request\n",
+      "    await super().execute_request(stream, ident, parent)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\kernelbase.py\", line 778, in execute_request\n",
+      "    reply_content = await reply_content\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\ipkernel.py\", line 449, in do_execute\n",
+      "    res = shell.run_cell(\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\zmqshell.py\", line 549, in run_cell\n",
+      "    return super().run_cell(*args, **kwargs)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\interactiveshell.py\", line 3075, in run_cell\n",
+      "    result = self._run_cell(\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\interactiveshell.py\", line 3130, in _run_cell\n",
+      "    result = runner(coro)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\async_helpers.py\", line 128, in _pseudo_sync_runner\n",
+      "    coro.send(None)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\interactiveshell.py\", line 3334, in run_cell_async\n",
+      "    has_raised = await self.run_ast_nodes(code_ast.body, cell_name,\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\interactiveshell.py\", line 3517, in run_ast_nodes\n",
+      "    if await self.run_code(code, result, async_=asy):\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\interactiveshell.py\", line 3577, in run_code\n",
+      "    exec(code_obj, self.user_global_ns, self.user_ns)\n",
+      "  File \"C:\\Users\\Yasaman\\AppData\\Local\\Temp\\ipykernel_36504\\2658778630.py\", line 1, in <module>\n",
+      "    from src.tempnet import temporal_network as tn\n",
+      "  File \"c:\\Users\\Yasaman\\temporal-networks\\src\\tempnet\\temporal_network.py\", line 30, in <module>\n",
+      "    import pandas as pd\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\__init__.py\", line 61, in <module>\n",
+      "    from pandas.core.api import (\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\core\\api.py\", line 9, in <module>\n",
+      "    from pandas.core.dtypes.dtypes import (\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\core\\dtypes\\dtypes.py\", line 24, in <module>\n",
+      "    from pandas._libs import (\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pyarrow\\__init__.py\", line 65, in <module>\n",
+      "    import pyarrow.lib as _lib\n"
+     ]
+    },
+    {
+     "ename": "AttributeError",
+     "evalue": "_ARRAY_API not found",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[1;31mAttributeError\u001b[0m: _ARRAY_API not found"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "A module that was compiled using NumPy 1.x cannot be run in\n",
+      "NumPy 2.4.3 as it may crash. To support both 1.x and 2.x\n",
+      "versions of NumPy, modules must be compiled with NumPy 2.0.\n",
+      "Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.\n",
+      "\n",
+      "If you are a user of the module, the easiest solution will be to\n",
+      "downgrade to 'numpy<2' or try to upgrade the affected module.\n",
+      "We expect that some modules will need time to support NumPy 2.\n",
+      "\n",
+      "Traceback (most recent call last):  File \"<frozen runpy>\", line 198, in _run_module_as_main\n",
+      "  File \"<frozen runpy>\", line 88, in _run_code\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel_launcher.py\", line 18, in <module>\n",
+      "    app.launch_new_instance()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\traitlets\\config\\application.py\", line 1075, in launch_instance\n",
+      "    app.start()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\kernelapp.py\", line 739, in start\n",
+      "    self.io_loop.start()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\tornado\\platform\\asyncio.py\", line 205, in start\n",
+      "    self.asyncio_loop.run_forever()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\asyncio\\base_events.py\", line 608, in run_forever\n",
+      "    self._run_once()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\asyncio\\base_events.py\", line 1936, in _run_once\n",
+      "    handle._run()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\asyncio\\events.py\", line 84, in _run\n",
+      "    self._context.run(self._callback, *self._args)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\kernelbase.py\", line 545, in dispatch_queue\n",
+      "    await self.process_one()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\kernelbase.py\", line 534, in process_one\n",
+      "    await dispatch(*args)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\kernelbase.py\", line 437, in dispatch_shell\n",
+      "    await result\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\ipkernel.py\", line 362, in execute_request\n",
+      "    await super().execute_request(stream, ident, parent)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\kernelbase.py\", line 778, in execute_request\n",
+      "    reply_content = await reply_content\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\ipkernel.py\", line 449, in do_execute\n",
+      "    res = shell.run_cell(\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\zmqshell.py\", line 549, in run_cell\n",
+      "    return super().run_cell(*args, **kwargs)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\interactiveshell.py\", line 3075, in run_cell\n",
+      "    result = self._run_cell(\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\interactiveshell.py\", line 3130, in _run_cell\n",
+      "    result = runner(coro)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\async_helpers.py\", line 128, in _pseudo_sync_runner\n",
+      "    coro.send(None)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\interactiveshell.py\", line 3334, in run_cell_async\n",
+      "    has_raised = await self.run_ast_nodes(code_ast.body, cell_name,\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\interactiveshell.py\", line 3517, in run_ast_nodes\n",
+      "    if await self.run_code(code, result, async_=asy):\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\interactiveshell.py\", line 3577, in run_code\n",
+      "    exec(code_obj, self.user_global_ns, self.user_ns)\n",
+      "  File \"C:\\Users\\Yasaman\\AppData\\Local\\Temp\\ipykernel_36504\\2658778630.py\", line 1, in <module>\n",
+      "    from src.tempnet import temporal_network as tn\n",
+      "  File \"c:\\Users\\Yasaman\\temporal-networks\\src\\tempnet\\temporal_network.py\", line 30, in <module>\n",
+      "    import pandas as pd\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\__init__.py\", line 61, in <module>\n",
+      "    from pandas.core.api import (\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\core\\api.py\", line 28, in <module>\n",
+      "    from pandas.core.arrays import Categorical\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\core\\arrays\\__init__.py\", line 1, in <module>\n",
+      "    from pandas.core.arrays.arrow import ArrowExtensionArray\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\core\\arrays\\arrow\\__init__.py\", line 5, in <module>\n",
+      "    from pandas.core.arrays.arrow.array import ArrowExtensionArray\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\core\\arrays\\arrow\\array.py\", line 53, in <module>\n",
+      "    from pandas.core import (\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\core\\ops\\__init__.py\", line 8, in <module>\n",
+      "    from pandas.core.ops.array_ops import (\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\core\\ops\\array_ops.py\", line 56, in <module>\n",
+      "    from pandas.core.computation import expressions\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\core\\computation\\expressions.py\", line 21, in <module>\n",
+      "    from pandas.core.computation.check import NUMEXPR_INSTALLED\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\core\\computation\\check.py\", line 5, in <module>\n",
+      "    ne = import_optional_dependency(\"numexpr\", errors=\"warn\")\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\compat\\_optional.py\", line 135, in import_optional_dependency\n",
+      "    module = importlib.import_module(name)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\importlib\\__init__.py\", line 126, in import_module\n",
+      "    return _bootstrap._gcd_import(name[level:], package, level)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\numexpr\\__init__.py\", line 24, in <module>\n",
+      "    from numexpr.interpreter import MAX_THREADS, use_vml, __BLOCK_SIZE1__\n"
+     ]
+    },
+    {
+     "ename": "AttributeError",
+     "evalue": "_ARRAY_API not found",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[1;31mAttributeError\u001b[0m: _ARRAY_API not found"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "A module that was compiled using NumPy 1.x cannot be run in\n",
+      "NumPy 2.4.3 as it may crash. To support both 1.x and 2.x\n",
+      "versions of NumPy, modules must be compiled with NumPy 2.0.\n",
+      "Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.\n",
+      "\n",
+      "If you are a user of the module, the easiest solution will be to\n",
+      "downgrade to 'numpy<2' or try to upgrade the affected module.\n",
+      "We expect that some modules will need time to support NumPy 2.\n",
+      "\n",
+      "Traceback (most recent call last):  File \"<frozen runpy>\", line 198, in _run_module_as_main\n",
+      "  File \"<frozen runpy>\", line 88, in _run_code\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel_launcher.py\", line 18, in <module>\n",
+      "    app.launch_new_instance()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\traitlets\\config\\application.py\", line 1075, in launch_instance\n",
+      "    app.start()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\kernelapp.py\", line 739, in start\n",
+      "    self.io_loop.start()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\tornado\\platform\\asyncio.py\", line 205, in start\n",
+      "    self.asyncio_loop.run_forever()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\asyncio\\base_events.py\", line 608, in run_forever\n",
+      "    self._run_once()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\asyncio\\base_events.py\", line 1936, in _run_once\n",
+      "    handle._run()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\asyncio\\events.py\", line 84, in _run\n",
+      "    self._context.run(self._callback, *self._args)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\kernelbase.py\", line 545, in dispatch_queue\n",
+      "    await self.process_one()\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\kernelbase.py\", line 534, in process_one\n",
+      "    await dispatch(*args)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\kernelbase.py\", line 437, in dispatch_shell\n",
+      "    await result\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\ipkernel.py\", line 362, in execute_request\n",
+      "    await super().execute_request(stream, ident, parent)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\kernelbase.py\", line 778, in execute_request\n",
+      "    reply_content = await reply_content\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\ipkernel.py\", line 449, in do_execute\n",
+      "    res = shell.run_cell(\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\ipykernel\\zmqshell.py\", line 549, in run_cell\n",
+      "    return super().run_cell(*args, **kwargs)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\interactiveshell.py\", line 3075, in run_cell\n",
+      "    result = self._run_cell(\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\interactiveshell.py\", line 3130, in _run_cell\n",
+      "    result = runner(coro)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\async_helpers.py\", line 128, in _pseudo_sync_runner\n",
+      "    coro.send(None)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\interactiveshell.py\", line 3334, in run_cell_async\n",
+      "    has_raised = await self.run_ast_nodes(code_ast.body, cell_name,\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\interactiveshell.py\", line 3517, in run_ast_nodes\n",
+      "    if await self.run_code(code, result, async_=asy):\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\IPython\\core\\interactiveshell.py\", line 3577, in run_code\n",
+      "    exec(code_obj, self.user_global_ns, self.user_ns)\n",
+      "  File \"C:\\Users\\Yasaman\\AppData\\Local\\Temp\\ipykernel_36504\\2658778630.py\", line 1, in <module>\n",
+      "    from src.tempnet import temporal_network as tn\n",
+      "  File \"c:\\Users\\Yasaman\\temporal-networks\\src\\tempnet\\temporal_network.py\", line 30, in <module>\n",
+      "    import pandas as pd\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\__init__.py\", line 61, in <module>\n",
+      "    from pandas.core.api import (\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\core\\api.py\", line 28, in <module>\n",
+      "    from pandas.core.arrays import Categorical\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\core\\arrays\\__init__.py\", line 1, in <module>\n",
+      "    from pandas.core.arrays.arrow import ArrowExtensionArray\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\core\\arrays\\arrow\\__init__.py\", line 5, in <module>\n",
+      "    from pandas.core.arrays.arrow.array import ArrowExtensionArray\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\core\\arrays\\arrow\\array.py\", line 67, in <module>\n",
+      "    from pandas.core.arrays.masked import BaseMaskedArray\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\core\\arrays\\masked.py\", line 61, in <module>\n",
+      "    from pandas.core import (\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\core\\nanops.py\", line 52, in <module>\n",
+      "    bn = import_optional_dependency(\"bottleneck\", errors=\"warn\")\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\pandas\\compat\\_optional.py\", line 135, in import_optional_dependency\n",
+      "    module = importlib.import_module(name)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\importlib\\__init__.py\", line 126, in import_module\n",
+      "    return _bootstrap._gcd_import(name[level:], package, level)\n",
+      "  File \"c:\\Users\\Yasaman\\anaconda3\\Lib\\site-packages\\bottleneck\\__init__.py\", line 7, in <module>\n",
+      "    from .move import (move_argmax, move_argmin, move_max, move_mean, move_median,\n"
+     ]
+    },
+    {
+     "ename": "AttributeError",
+     "evalue": "_ARRAY_API not found",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[1;31mAttributeError\u001b[0m: _ARRAY_API not found"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Could not load sparse_dot_mkl. Will use scipy.sparse for matrix products.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from src.tempnet import temporal_network as tn\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "540a5429",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext line_profiler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "8d8cf74f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from line_profiler import profile\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "9a0847c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_network_from_csv(url, cut_after):\n",
+    "    raw_df = pd.read_csv(url,compression='gzip')\n",
+    "    if cut_after is not None:\n",
+    "        raw_df = raw_df[raw_df['ending_times'] < cut_after]\n",
+    "        \n",
+    "    source_nodes = raw_df['source_nodes'].tolist()\n",
+    "    target_nodes = raw_df['target_nodes'].tolist()\n",
+    "    starting_times = raw_df['starting_times'].tolist()\n",
+    "    ending_times = raw_df['ending_times'].tolist()\n",
+    "    return source_nodes, target_nodes,starting_times, ending_times"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "708bcb93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = 'https://zenodo.org/record/4725155/files/'\\\n",
+    "                        'mice_contact_sequence.csv.gz'\n",
+    "cut_after = 24*3600 # only use first day\n",
+    "source_nodes, target_nodes,starting_times, ending_times=load_network_from_csv(url, cut_after)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "1bd1071f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cont_net=tn.ContTempNetwork(\\\n",
+    "    source_nodes=source_nodes,\\\n",
+    "    target_nodes=target_nodes,\\\n",
+    "    starting_times=starting_times,\\\n",
+    "    ending_times=ending_times\\\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "8d569119",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'src.tempnet.temporal_network.ContTempNetwork'> with 414 nodes and 132034 events\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(cont_net)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "51f159fd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "256 ms ± 10.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%timeit cont_net.compute_static_adjacency_matrix(new=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "cdbd9a20",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "19.9 ms ± 651 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%timeit cont_net.compute_static_adjacency_matrix(new=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/tempnet/logger.py
+++ b/src/tempnet/logger.py
@@ -1,0 +1,46 @@
+import os
+import logging
+
+# Create a logger instance
+logger = logging.getLogger("flowstab")
+
+class CustomPathnameFilter(logging.Filter):
+    def filter(self, record):
+        # Get the full pathname
+        full_path = record.pathname
+        
+        # Split the path into parts
+        path_parts = full_path.split(os.sep)
+        
+        # Limit to the last 2 parts
+        if len(path_parts) > 2:
+            record.pathname = os.sep.join(path_parts[-2:])
+        return True
+
+def setup_logger(log_level=logging.INFO):
+    """
+    Set up the logger for the package.
+
+    Args:
+        log_level (int): The logging level (e.g., logging.DEBUG, logging.INFO).
+    """
+    logger.setLevel(log_level)
+
+    logger.addFilter(CustomPathnameFilter())
+
+    # Create console handler and set level
+    ch = logging.StreamHandler()
+    ch.setLevel(log_level)
+
+    # Create formatter
+    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(pathname)s:%(lineno)d - PID:%(process)d - %(message)s')
+    # Add formatter to ch
+    ch.setFormatter(formatter)
+
+    # Add ch to logger if it doesn't have handlers
+    if not logger.hasHandlers():
+        logger.addHandler(ch)
+
+def get_logger():
+    """Return the logger instance."""
+    return logger

--- a/src/tempnet/parallel_expm.py
+++ b/src/tempnet/parallel_expm.py
@@ -1,0 +1,268 @@
+"""#
+# flow stability
+#
+# Copyright (C) 2021 Alexandre Bovet <alexandre.bovet@maths.ox.ac.uk>
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+"""
+
+import os
+import time
+from multiprocessing import Pool, RawArray
+
+import numpy as np
+from scipy.sparse import csc_matrix, csr_matrix, isspmatrix_csc, vstack
+from scipy.sparse.csgraph import connected_components
+from scipy.sparse.linalg import expm, expm_multiply
+
+from .sparse_stoch_mat import inplace_csr_row_normalize
+
+# A global dictionary storing the variables passed from the initializer.
+var_dict = {}
+
+
+def _init_worker(data, indices, indptr, N):
+    # reconstruct A from shared arrays
+    var_dict["A"] = csc_matrix((np.frombuffer(data, dtype=np.float64),
+                                  np.frombuffer(indices, dtype=np.int32),
+                                  np.frombuffer(indptr, dtype=np.int32)),
+                                 shape=(N,N))
+    var_dict["N"] = N
+
+def _worker(args):
+
+    i, thresh_ratio = args
+
+    delta_i = np.zeros(var_dict["N"],
+                       dtype=np.float64)
+    delta_i[i] = 1.0
+
+    Tcol_i = expm_multiply(var_dict["A"],
+                         delta_i)
+
+    if thresh_ratio is not None:
+
+        Tcol_i[Tcol_i<Tcol_i.max()/thresh_ratio]=0
+
+    return csc_matrix(Tcol_i)
+
+def compute_parallel_expm(A, nproc=1, thresh_ratio=None,
+                          normalize_rows=True,
+                          verbose=True):
+    """Computes the exponential matrix of A by computing each column separately
+    exploiting the fact that the column i of expm(A) is expm_multiply(A,delta_i)
+    where delta i is the vector with zeros everywhere except on i.
+    This only works if A is equal to (minus) a Laplacian matrix
+    
+    
+    Parameters
+    ----------
+    A : scipy csc sparse matrix
+        Square csc sparse matrix representing (+ or -) a Laplacian.
+        If A is not csc, it will be converted to csc format.
+    nproc : int, optional
+        number of parallel processes. The default is 1.
+    thresh_ratio: float, optional.
+        Threshold ratio used to trim negligible values in the resulting matrix.
+        For each columns `c`, values smaller than `max(c)/thresh_ratio` are set to 
+        zero. Default is None.
+    normalize_rows: bool, optional.
+        Whether rows of the resulting matrix are normalized to sum to 1.
+
+
+    Returns
+    -------
+    expm(A).
+        scipy csr sparse matrix
+
+    """
+    if not isspmatrix_csc(A):
+        A = csc_matrix(A)
+
+    N = A.shape[0]
+
+    # create arrays to share A between processes
+    indices = RawArray("i",A.indices)
+    indptr = RawArray("i",A.indptr)
+    data = RawArray("d", A.data)
+
+    if verbose:
+        print("PID ", os.getpid(), " : ",f"compute_parallel_expm starting a pool of {nproc} workers")
+    t0 = time.time()
+    with Pool(nproc, initializer=_init_worker,
+              initargs=(data, indices, indptr, N)) as p:
+        res = p.map(_worker, [(i,thresh_ratio) for i in range(N)])
+
+    # delete shared arrays
+    global var_dict
+    var_dict = {}
+
+    # seems faster than _stack_sparse_cols
+    T = vstack(res).T.tocsr()
+
+    if normalize_rows:
+        inplace_csr_row_normalize(T)
+
+    if verbose:
+        print("PID ", os.getpid(), " : ", f"compute_parallel_expm took {time.time()-t0:.3f}s, computed expm has {T.getnnz()} non-zeros.")
+
+    return T
+
+def _stack_sparse_cols(col_list):
+
+    # create csc sparse matric from sparse column list
+    data_size = sum(C.data.size for C in col_list)
+    N = max(col_list[0].shape)
+
+    data = np.zeros(data_size, dtype=np.float64)
+    indices = np.zeros(data_size, dtype=np.int32)
+    indptr = np.zeros(N+1, dtype=np.int32)
+
+    ptr = 0
+    for col, C in enumerate(col_list):
+        nnz_col = C.data.size
+        data[ptr:ptr+nnz_col] = C.T.tocsc().data
+        indices[ptr:ptr+nnz_col] = C.T.tocsc().indices
+        ptr = ptr + nnz_col
+        indptr[col+1] = ptr
+
+
+    return csc_matrix((data, indices, indptr), shape=(N,N))
+
+def _expm_worker(cmp_ind):
+
+    return expm(var_dict["A"][cmp_ind,:][:,cmp_ind]).toarray()
+
+
+def compute_subspace_expm_parallel(A, n_comp=None, comp_labels=None, verbose=False,
+                           nproc=1,
+                           thresh_ratio=None,
+                           normalize_rows=True):
+    """Compute the exponential matrix of `A` by applying expm on each connected
+    subgraphs defined by A and recomposing it to return expm(A).
+    Small subgraphs are computed in parallel, each using scipy expm,
+    and large subgraphs are computed with compute_parallel_expm.
+
+    Parameters
+    ----------
+        A : scipy.sparse.csc_matrix
+        
+    nproc : int, optional
+        number of parallel processes. The default is 1.
+    thresh_ratio: float, optional.
+        Threshold ratio used to trim negligible values in the resulting matrix.
+        Values smaller than `max(expm(A))/thresh_ratio` are set to 
+        zero. Default is None.
+    normalize_rows: bool, optional.
+        Whether rows of the resulting matrix are normalized to sum to 1.
+        
+
+    Returns
+    -------
+        expm(A) : scipy.sparse.csr_matrix
+        matrix exponential of A
+            
+    """
+    num_nodes = A.shape[0]
+
+    # otherwise 0 values may count as an edge
+    A.eliminate_zeros()
+    A.sort_indices()
+
+    if (n_comp is None) or (comp_labels is None):
+        n_comp, comp_labels = connected_components(A,directed=False)
+    comp_sizes = np.bincount(comp_labels)
+    cmp_indices = [(comp_labels == cmp).nonzero()[0] for \
+                          cmp in range(n_comp)]
+
+    if verbose:
+        print("PID ", os.getpid(), f" : subspace_expm with {n_comp} components")
+
+
+    large_comps, = np.nonzero(comp_sizes >= 1000)
+    small_comps, = np.nonzero(comp_sizes < 1000)
+
+    subnets_expms = dict()
+    # first compute large comps with exmp_multiply
+    for cmp in large_comps:
+        cmp_ind = cmp_indices[cmp]
+        if verbose:
+            print("PID ", os.getpid(), f" : computing component {cmp} over {n_comp}, with size {cmp_ind.size} using expm_multiply")
+        subnets_expms[cmp] = compute_parallel_expm(A[cmp_ind,:][:,cmp_ind],
+                                                   nproc=nproc,
+                                                   thresh_ratio=None,
+                                                   normalize_rows=False,
+                                                   verbose=verbose,
+                                                   ).toarray()
+
+
+    Aindices = RawArray("i",A.indices)
+    Aindptr = RawArray("i",A.indptr)
+    Adata = RawArray("d", A.data)
+
+    # now compute small comps in parallel
+    if verbose:
+            print("PID ", os.getpid(), f" : computing {small_comps.size} small components with {nproc} workers")
+    t0 = time.time()
+    with Pool(nproc, initializer=_init_worker,
+          initargs=(Adata, Aindices, Aindptr, num_nodes)) as p:
+        res = p.map(_expm_worker, [cmp_indices[c] for c in small_comps])
+
+    # delete shared arrays
+    global var_dict
+    var_dict = {}
+
+    if verbose:
+            print("PID ", os.getpid(), f" : small components computation took {time.time()-t0:.3f}s")
+    t0 = time.time()
+
+    # organize results
+    for c, sub_expm in zip(small_comps, res):
+        subnets_expms[c] = sub_expm
+
+    # constructors for sparse array
+    data = np.zeros((comp_sizes**2).sum(), dtype=np.float64)
+    indices = np.zeros((comp_sizes**2).sum(), dtype=np.int32)
+    indptr = np.zeros(num_nodes+1, dtype=np.int32)
+
+    # reconstruct csr sparse matrix
+    if verbose:
+            print("PID ", os.getpid(), " : reconstructing expm mat")
+    data_ind = 0
+    for row in range(num_nodes):
+        cmp = comp_labels[row]
+        cmp_expm = subnets_expms[cmp]
+        sub_expm_row, = np.where(cmp_indices[cmp] == row)
+
+        data[data_ind:data_ind+comp_sizes[cmp]] = cmp_expm[sub_expm_row,:]
+
+        indices[data_ind:data_ind+comp_sizes[cmp]] = cmp_indices[cmp]
+
+        indptr[row] = data_ind
+
+        data_ind += comp_sizes[cmp]
+    indptr[num_nodes] = data_ind
+
+    expmA = csr_matrix((data, indices, indptr), shape=(num_nodes,num_nodes),
+                    dtype=np.float64)
+
+    if thresh_ratio is not None:
+        expmA.data[expmA.data<expmA.data.max()/thresh_ratio] = 0.0
+        expmA.eliminate_zeros()
+    if normalize_rows:
+        inplace_csr_row_normalize(expmA)
+
+    return expmA

--- a/src/tempnet/sparse_stoch_mat.py
+++ b/src/tempnet/sparse_stoch_mat.py
@@ -1,0 +1,1177 @@
+"""#
+# flow stability
+#
+# Copyright (C) 2021 Alexandre Bovet <alexandre.bovet@maths.ox.ac.uk>
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 3 of the License, or (at your option) any
+# later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import time
+from collections.abc import Callable
+from copy import copy
+from functools import wraps
+
+from typing import Union
+import numpy as np
+from numpy.typing import NDArray
+from scipy.sparse import (
+    coo_matrix,
+    csr_matrix,
+    csc_matrix,
+    eye,
+    isspmatrix_csc,
+    isspmatrix_csr,
+    spmatrix,
+)
+from scipy.sparse._sparsetools import csr_scale_columns, csr_scale_rows
+
+if importlib.util.find_spec("cython") is not None:
+    import _cython_sparse_stoch as _css
+else:
+    print("Could not load cython functions. Some functionality might be broken.")
+    from . import _cython_subst as _css
+
+USE_SPARSE_DOT_MKL = True
+if importlib.util.find_spec("sparse_dot_mkl") is not None:
+    from sparse_dot_mkl import dot_product_mkl, gram_matrix_mkl
+    from sparse_dot_mkl._mkl_interface import MKL
+    print("MKL_INT_NUMPY", MKL.MKL_INT_NUMPY)
+else:
+    USE_SPARSE_DOT_MKL = False
+    print("Could not load sparse_dot_mkl. Will use scipy.sparse for matrix products.")
+
+# timing decorator
+def timing(f:Callable)->Callable:
+    """
+    """
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        start = time.time()
+        result = f(*args, **kwargs)
+        end = time.time()
+        if kwargs.get("verbose"):
+            log = f"PID  {os.getpid()} : function {f.__name__}" +\
+                  f", elapsed time: {end-start:.4e} s"
+            if "log_message" in kwargs and len(kwargs["log_message"])>0:
+                log += ", " + kwargs["log_message"]
+
+            print(log)
+        return result
+    return wrapper
+
+
+class SparseStochMat:
+    """A sparse stochastic matrix representation.
+        
+    Represents a matrix as an array of indices corresponding to 
+    row/colums that do not have only a 1 on the diagonal and a 
+    smaller CSR scipy sparse matrix containing the these rows/colums.
+        
+    """
+
+    def __init__(self, size:int, data:NDArray, indices:NDArray, indptr:NDArray,
+                 nz_rowcols:NDArray, diag_val:float=1.0):
+        """Initialize SparseStochMat
+
+        The SparseStochMat will be a square matrix of size `size` with
+        row/columns of a diagonal matrix for every row/column index not present
+        in `nz_rowcols`.
+        For the row/column indices present in `nz_rowcols` the matching
+        row/column of a `scipy.sparce.csr_matrix`, called `T_small` will be
+        used to fill the empty cells in the matrix.
+        
+        .. note::
+          A concise explanation of how sparse matrices are represented in
+          `csr`-format can be found
+          [on StackOverflow](https://stackoverflow.com/a/52299730/1622937).
+
+
+        Parameters
+        ----------
+        size:
+          Determines the number of rows/columns in of the matrix
+        data:
+          See `scipy.sparse.csr_matrix` for details
+        indices:
+          See `scipy.sparse.csr_matrix` for details
+        indptr:
+          See `scipy.sparse.csr_matrix` for details
+        nz_rowcols:
+          A collection of column (or row) indexes into which the columns
+          (or rows) of `T_small` map.
+
+          For all index values < `size`, the corresponding rows and columns
+          will be filled with the row/column from a diagnoal matrix if the
+          index is not present in `nz_rowcols` and 
+
+          ..Note::
+            The number of elements in `nz_rowcols` must match the size
+            of `T_small`.
+        diag_val:
+          The value to use on the diagnoal in diagonal row/colums.
+        
+
+        """
+
+        self.size = size
+        self.nz_rowcols = np.unique(np.array(nz_rowcols, dtype=np.int32)) #sorted unique
+        self.T_small = csr_matrix((np.array(data, dtype=np.float64),
+                                   np.array(indices, dtype=np.int32),
+                                   np.array(indptr, dtype=np.int32)),
+                                  shape=(len(nz_rowcols),
+                                         len(nz_rowcols)))
+        self.diag_val = diag_val
+        self.shape = (size,size)
+
+
+    @classmethod
+    def from_small_csr_matrix(cls, size:int, T_small:csr_matrix, nz_rowcols:NDArray,
+                              diag_val:float=1.0)->SparseStochMat:
+        """Initialize SparseStochMat from a small csr_matrix
+
+        The SparseStochMat will be a square matrix of size `size` with
+        row/columns of a diagonal matrix for every row/column index not present
+        in `nz_rowcols`. For the row/column indices present in `nz_rowcols`
+        the matching row/column of `T_small` will be used to fill the empty
+        cells in the matrix.
+
+
+        Parameters
+        ----------
+        size:
+          Determines the number of rows/columns in of the matrix
+        T_small:
+          A scipy.sparse.csr_matrix that does not contain any rows/columns
+          of a diagonal matrix.
+        nz_rowcols:
+          A collection of column (or row) indexes into which the columns
+          (or rows) of `T_small` map.
+
+          For all index values < `size`, the corresponding rows and columns
+          will be filled with the row/column from a diagnoal matrix if the
+          index is not present in `nz_rowcols` and 
+
+          ..Note::
+            The number of elements in `nz_rowcols` must match the size
+            of `T_small`.
+        diag_val:
+          The value to use on the diagnoal in diagonal row/colums.
+        
+
+        """
+        if not isspmatrix_csr(T_small):
+            raise TypeError("T_small must be in CSR format.")
+
+        return cls(size, T_small.data, T_small.indices, T_small.indptr,
+                   nz_rowcols, diag_val=diag_val)
+
+    @classmethod
+    def from_full_csr_matrix(cls, Tcsr:csr_matrix, nz_rowcols:NDArray|None=None,
+                             diag_val:float=1.0)->SparseStochMat:
+        """Init SparseStochMat from a full size row stochastic csr_matrix
+        """
+        if not isspmatrix_csr(Tcsr):
+            raise TypeError("T_small must be in CSR format.")
+
+        if nz_rowcols is None:
+            nz_rows, nz_cols = (Tcsr - diag_val * eye(Tcsr.shape[0], format="csr")).nonzero()
+            nz_rowcols = np.union1d(nz_rows,nz_cols)
+
+        res = _css.sparse_stoch_from_full_csr(
+                np.array(nz_rowcols, dtype=np.int32),
+                Tcsr.data.astype(dtype=np.float64),
+                Tcsr.indices,
+                Tcsr.indptr,
+                diag_val)
+
+        return cls(*res)
+
+
+    @classmethod
+    def create_diag(cls, size:int, diag_val:float=1.0)->SparseStochMat:
+        """Returns a diagonal matrix with an empty T_small.
+
+        Parameters
+        ----------
+        size : int
+            linear size of the matrix.
+        diag_val : float, optional
+            Value of the diagonal. The default is 1.0.
+
+        """
+        T_small = csr_matrix((0,0))
+
+        return cls.from_small_csr_matrix(size, T_small, np.array([]), diag_val=diag_val)
+
+    def inplace_row_normalize(self, row_sum:float=1.0):
+        """Normalize the rows in place
+        """
+
+        self.T_small.indptr = self.T_small.indptr.astype(np.int64, copy=False)
+        self.T_small.indices = self.T_small.indices.astype(np.int64, copy=False)
+
+        _css.inplace_csr_row_normalize(self.T_small.data, self.T_small.indptr,
+                                       self.T_small.shape[0], row_sum)
+
+        self.diag_val = row_sum
+
+
+    def set_to_zeroes(self, tol:float=1e-8, relative:bool=True, use_absolute_value:bool=False):
+        """In place replaces zeroes in the T_small sparse matrix that are,
+        within the tolerence, close to zero with actual zeroes
+        """
+        if self.T_small.data.size > 0:
+            if relative:
+                tol = tol*np.abs([self.T_small.data.min(),self.T_small.data.max()]).max()
+
+            if use_absolute_value:
+                self.T_small.data[np.abs(self.T_small.data) <= tol] = 0
+            else:
+                self.T_small.data[self.T_small.data <= tol] = 0
+
+            self.T_small.eliminate_zeros()
+
+
+    def to_full_mat(self)->csr_matrix:
+        """Returns a full size sparse matrix"""
+        return rebuild_nnz_rowcol(self.T_small,
+                                  self.nz_rowcols,
+                                  self.size,
+                                  self.diag_val)
+
+    def tocsr(self):
+
+        return self.to_full_mat()
+
+    def toarray(self):
+
+        return self.to_full_mat().toarray()
+
+    def copy(self):
+
+        return SparseStochMat.from_small_csr_matrix(copy(self.size),
+                                                      self.T_small.copy(),
+                                                      self.nz_rowcols.copy(),
+                                                      copy(self.diag_val))
+    def to_dict(self):
+
+        return {"size" : self.size,
+                "data" : self.T_small.data,
+                "indices" : self.T_small.indices,
+                "indptr" : self.T_small.indptr,
+                "nz_rowcols" : self.nz_rowcols,
+                 "diag_val" : self.diag_val}
+
+    def sub_diag(self, diag_val=1.0):
+        """Returns a SparseStochMatrix results of
+        self - diag(diag_val)
+        """
+        return SparseStochMat.from_small_csr_matrix(self.size,
+                                                      self.T_small - diag_val*eye(self.T_small.shape[0],
+                                                                                  format="csr"),
+                                                      self.nz_rowcols,
+                                                      self.diag_val-diag_val)
+    def add_diag(self, diag_val=1.0):
+        """Returns a SparseStochMatrix results of
+        self + diag(diag_val)
+        """
+        return SparseStochMat.from_small_csr_matrix(self.size,
+                                                      self.T_small + diag_val*eye(self.T_small.shape[0],
+                                                                                  format="csr"),
+                                                      self.nz_rowcols,
+                                                      self.diag_val+diag_val)
+
+    def transpose(self, copy=False):
+
+        if copy:
+            nz_rowcols = self.nz_rowcols.copy()
+        else:
+            nz_rowcols = self.nz_rowcols
+        return SparseStochMat.from_small_csr_matrix(self.size,
+                                                      T_small=self.T_small.transpose(copy=copy).tocsr(),
+                                                      nz_rowcols=nz_rowcols,
+                                                      diag_val=self.diag_val)
+    @property
+    def T(self):
+        return self.transpose()
+
+    def check_nz_intersect_len(self, B):
+        """Returns the length of the intersection of self.nz_rowcols and B.nz_rowcols"""
+        if isinstance(B, SparseStochMat):
+
+            return len(set(self.nz_rowcols).intersection(set(B.nz_rowcols)))
+
+        else:
+            raise TypeError("B must be a SparseStochMat")
+
+
+    def __repr__(self):
+
+        return f"{self.size}x{self.size} stochastic sparse matrix with T_small:\n" + \
+              self.T_small.__repr__()
+
+    def __add__(self, B):
+        """Addition of two sparse stoch mat
+        C = A + B 
+            
+        """
+        if isinstance(B, SparseStochMat):
+
+            if not self.T_small.has_canonical_format:
+                self.T_small.sort_indices()
+
+            if not B.T_small.has_canonical_format:
+                B.T_small.sort_indices()
+
+            size, Cdata,Cindices,Cindptr, Cnz_rowcols, Cdiag_val = \
+                _css.stoch_mat_add(self.size, # big matrix size
+                                   self.T_small.data,
+                                   self.T_small.indices,
+                                   self.T_small.indptr,
+                                   self.nz_rowcols,
+                                   self.diag_val,
+                                   B.T_small.data,
+                                   B.T_small.indices,
+                                   B.T_small.indptr,
+                                   B.nz_rowcols,
+                                   B.diag_val)
+
+            return SparseStochMat(size,Cdata,Cindices,Cindptr,
+                                    Cnz_rowcols, Cdiag_val)
+
+
+        elif isinstance(B, (spmatrix, np.ndarray)):
+            return self.to_full_mat() + B
+        else:
+            raise NotImplementedError
+
+    def __radd__(self, B):
+        """Addition of two sparse stoch mat
+        C = B + A = A + B 
+            
+        """
+        return self.__add__(B)
+
+    def __sub__(self, B):
+        """Substraction of two sparse stoch mat.
+        """
+        if isinstance(B, SparseStochMat):
+
+            if not self.T_small.has_canonical_format:
+                self.T_small.sort_indices()
+
+            if not B.T_small.has_canonical_format:
+                B.T_small.sort_indices()
+
+            size, Cdata,Cindices,Cindptr, Cnz_rowcols, Cdiag_val = \
+                _css.stoch_mat_sub(self.size, # big matrix size
+                                   self.T_small.data,
+                                   self.T_small.indices,
+                                   self.T_small.indptr,
+                                   self.nz_rowcols,
+                                   self.diag_val,
+                                   B.T_small.data,
+                                   B.T_small.indices,
+                                   B.T_small.indptr,
+                                   B.nz_rowcols,
+                                   B.diag_val)
+
+            return SparseStochMat(size,Cdata,Cindices,Cindptr,
+                                    Cnz_rowcols, Cdiag_val)
+
+        elif isinstance(B, (spmatrix, np.ndarray)):
+            return self.to_full_mat() - B
+        else:
+            raise NotImplementedError
+
+    def __rsub__(self, B):
+
+        if isinstance(B, (spmatrix, np.ndarray)):
+            return B - self.to_full_mat()
+        else:
+            raise NotImplementedError
+
+    def __matmul__(self, B):
+        """Matrix multiplication with self on the left and B on the right.
+        
+        C = A @ B
+            
+        """
+        if isinstance(B, SparseStochMat):
+            # We split the problem in A @ B = (A-aI) @ (B-bI) + b*A + a*B - a*b*I
+            # where a is the diag_val of A and b is the diag_val of B
+            # Moreover, if intersection(A.nz_rowvals,B.nz_rowvals) = [],
+            # (A-aI) @ (B-bI) = 0 and there is no multiplication to do
+
+            if not self.T_small.has_canonical_format:
+                self.T_small.sort_indices()
+
+            if not B.T_small.has_canonical_format:
+                B.T_small.sort_indices()
+
+            Anz_set = set(self.nz_rowcols)
+            Bnz_set = set(B.nz_rowcols)
+            Cnz_set = Anz_set.union(Bnz_set)
+
+            interset = Anz_set.intersection(Bnz_set)
+
+            if self.diag_val == 1.0:
+                aB = B # avoid making a copy of B
+            else:
+                aB = self.diag_val * B
+            if B.diag_val == 1.0:
+                bA = self
+            else:
+                bA = B.diag_val * self
+
+            if len(interset) == 0:
+                # no need to compute (A-aI) @ (B-bI)
+                return (bA + aB).sub_diag(self.diag_val * B.diag_val)
+            else:
+                # we need to compute (A-aI) @ (B-bI)
+
+                # size of C.T_small
+                small_size = len(Cnz_set)
+
+                Cnz_rowcols = sorted(list(Cnz_set))
+
+                # A/B to C col mapping
+                Acol_to_Ccol = np.zeros(self.nz_rowcols.size, dtype=np.int32)
+
+                ia_col = 0
+                ic_col = 0
+                for ia_col in range(self.nz_rowcols.size): # map col in A to col in C
+                    while self.nz_rowcols[ia_col] != Cnz_rowcols[ic_col]:
+                        ic_col+=1
+                    Acol_to_Ccol[ia_col] = ic_col
+
+                Bcol_to_Ccol = np.zeros(B.nz_rowcols.size, dtype=np.int32)
+
+                ib_col = 0
+                ic_col = 0
+                for ib_col in range(B.nz_rowcols.size): # map col in A to col in C
+                    while B.nz_rowcols[ib_col] != Cnz_rowcols[ic_col]:
+                        ic_col+=1
+                    Bcol_to_Ccol[ib_col] = ic_col
+
+                # we just have to compute Anz_rowcols * Bnz_rowcols values
+                # C values will be on rows of Anz_rowcols and columns of Bnz_rowcols
+
+                # build two small_size x small_size matrices for (A-aI) and
+                # (B-bI) in the subspace of Csmall and take their product
+                AmI_small = SparseStochMat.from_small_csr_matrix(small_size,
+                                                                self.T_small - \
+                                                                    self.diag_val * eye(self.T_small.shape[0],
+                                                                                        format="csr"),
+                                                                Acol_to_Ccol,
+                                                                diag_val=0.0)
+
+                BmI_small = SparseStochMat.from_small_csr_matrix(small_size,
+                                                                B.T_small - \
+                                                                    B.diag_val * eye(B.T_small.shape[0],
+                                                                                        format="csr"),
+                                                                Bcol_to_Ccol,
+                                                                diag_val=0.0)
+
+                CmI = SparseStochMat.from_small_csr_matrix(self.size,
+                                                             AmI_small.tocsr() @ BmI_small.tocsr(),
+                                                             Cnz_rowcols,
+                                                             diag_val=0.0)
+
+                return CmI + (bA + aB).sub_diag(self.diag_val * B.diag_val)
+
+
+        elif isinstance(B, (spmatrix, np.ndarray)):
+            return self.to_full_mat() @ B
+
+        else:
+            raise NotImplementedError
+
+    def __rmatmul__(self, s2):
+        """Matrix multiplication with self on the right and s2 on the left.
+        simply convert to full size sparse mat and 
+        perform operation.
+        """
+        if isinstance(s2, (spmatrix, np.ndarray)):
+            return s2 @ self.to_full_mat()
+        else:
+            raise NotImplementedError
+
+    def __mul__(self, o):
+        """Scalar multiplication with self on the right and o on the left.
+        """
+        if isinstance(o, (float,int)):
+
+            return SparseStochMat(self.size,
+                                    self.T_small.data*o,
+                                    self.T_small.indices.copy(),
+                                    self.T_small.indptr.copy(),
+                                    self.nz_rowcols.copy(),
+                                    self.diag_val*o)
+        else:
+            raise NotImplementedError
+
+    def __rmul__(self, o):
+        """Scalar multiplication with self on the left and o on the right.
+
+        """
+        return self.__mul__(o)
+
+
+def inplace_csr_row_normalize(X, row_sum=1.0):
+    """Row normalize scipy sparse csr matrices inplace such that each row sum
+    to `row_sum` (default is 1.0).
+        
+    If `row_sum=0` will remove the mean from the row, but only on nnz values.
+    Skips rows that sum to 0.
+        
+    inspired from sklearn sparsefuncs_fast.pyx.
+        
+    Parameters
+    ----------
+        X : csr_matrix or SparseStochMat
+        Matrix to be row normalized
+        
+    row_sum : float or ndarray of same linear size than X (default is 1.0).
+        Desired value of the sum of the rows
+            
+    Returns
+    -------
+        None : operates in place.
+
+    """
+    if isinstance(X, SparseStochMat):
+        X.inplace_row_normalize(row_sum=row_sum)
+    elif isspmatrix_csr(X) or isspmatrix_csc(X):
+        if isspmatrix_csc(X):
+            print("Warning: row normalization on a CSC matrix will normalize columns.")
+        # TODO: resolve this once both cython functions are called via _css
+        # if isinstance(row_sum, float):
+        #     row_sum = np.ones(X.shape[0])*row_sum
+        # for i in range(X.shape[0]):
+        #     row_sum_tmp = X.data[X.indptr[i]:X.indptr[i+1]].sum()
+        #     if row_sum_tmp != 0:
+        #         if row_sum[i] == 0.0:
+        #             X.data[X.indptr[i]:X.indptr[i+1]] -= row_sum_tmp/(X.indptr[i+1]-X.indptr[i])
+        #         else:
+        #             X.data[X.indptr[i]:X.indptr[i+1]] /= (row_sum_tmp/row_sum[i])
+        X.indptr = X.indptr.astype(np.int64, copy=False)
+        X.indices = X.indices.astype(np.int64, copy=False)
+        if isinstance(row_sum, float):
+            _css.inplace_csr_row_normalize(X.data, X.indptr,
+                                                X.shape[0], row_sum)
+
+        elif isinstance(row_sum, np.ndarray) and row_sum.dtype == np.float64:
+            assert row_sum.shape[0] == X.shape[0] and len(row_sum.shape) == 1
+
+            _css.inplace_csr_row_normalize_array(X.data, X.indptr,
+                                                    X.shape[0], row_sum)
+        else:
+            raise TypeError("row_sum must by float or ndarray of floats")
+    else:
+        raise TypeError("X must be in ndarray, CSR or SparseStochMat format.")
+
+def rebuild_nnz_rowcol(T_small:csr_matrix, nonzero_indices:NDArray,
+                       size:int, diag_val:float=1.0)->csr_matrix:
+    """Returns a CSR matrix built from the CSR matrix T_small with
+    T_small values at row-colums corresponding to nonzero_indices 
+    and 1 on the diagonal elsewhere.
+        
+    Returns
+    -------
+        T_full_size : scipy csr sparse matrix
+        Full size transition matrix
+
+    """
+    (data, indices, indptr, n_rows) = \
+                _css.rebuild_nnz_rowcol(T_small.data,
+                                        T_small.indices.astype(np.int64, copy=False),
+                                        T_small.indptr.astype(np.int64, copy=False),
+                                        nonzero_indices.astype(np.int64, copy=False),
+                                        size,
+                                        diag_val)
+    return csr_matrix((data, indices, indptr),
+                       shape=(size,size))
+
+
+def inplace_csr_matmul_diag(A, diag_vec):
+    """Inplace multiply a csr matrix A with a diag matrix D
+    
+    A = A @ D
+
+    With D = np.diagflat(diag_vec) and A a scipy.sparse.cs[rc]_matrix,
+    i.e. column i of A is scaled by diag_vec[i]
+        
+    """
+    assert isinstance(diag_vec, np.ndarray)
+
+    diag_vec = diag_vec.squeeze()
+
+    assert diag_vec.shape[0] == diag_vec.size
+
+    assert A.shape[1] == diag_vec.size, "Invalid array size"
+
+
+    if isspmatrix_csr(A):
+
+        csr_scale_columns(A.shape[0], A.shape[1], A.indptr,
+                          A.indices, A.data, diag_vec)
+
+    elif isspmatrix_csc(A):
+        csr_scale_rows(A.shape[0], A.shape[1], A.indptr,
+                          A.indices, A.data, diag_vec)
+
+    else:
+        raise ValueError("A must be a csr or csc matrix")
+
+
+
+def inplace_diag_matmul_csr(A:csr_matrix | csc_matrix, diag_vec: NDArray)->None:
+    """Inplace multiply a diag matrix D with a csr matrix A:
+    
+    A = D @ A
+        
+    With D = np.diagflat(diag_vec) and A a scipy.sparse.cs[rc]_matrix,
+    i.e. row i of A is scaled by diag_vec[i]
+        
+    """
+    assert isinstance(diag_vec, np.ndarray)
+
+    diag_vec = diag_vec.squeeze()
+
+    assert diag_vec.shape[0] == diag_vec.size
+
+    assert A.shape[1] == diag_vec.size, "Invalid array size"
+
+
+    if isspmatrix_csr(A):
+        csr_scale_rows(A.shape[0], A.shape[1], A.indptr,
+                       A.indices, A.data, diag_vec)
+
+    elif isspmatrix_csc(A):
+        csr_scale_columns(A.shape[0], A.shape[1], A.indptr,
+                          A.indices, A.data, diag_vec)
+
+    else:
+        raise ValueError("A must be a csr or csc matrix")
+
+
+class SparseAutocovMat:
+    """Class for autocovariance matrix in the form:
+        
+        S = PT - P0
+            
+    where PT = diag(p) @ T, is a sparse csr matrix 
+    and P0 = np.outer(p1,p2) is a dense matrix
+        
+    only PT, p1 and p2 are stored for memory efficiency
+            
+    """
+
+    def __init__(self, PT:csr_matrix,
+                 p1: Union[float, int, np.number, NDArray],
+                 p2: Union[float, int, np.number, NDArray],
+                 PT_symmetric:bool=False):
+
+        assert isspmatrix_csr(PT)
+        if isinstance(p1, np.ndarray) and isinstance(p2, np.ndarray):
+            assert not isinstance(p1, np.matrix)
+            assert not isinstance(p2, np.matrix)
+            assert len(p2.shape) == 1
+            assert len(p1.shape) == 1
+            assert PT.shape[0] == PT.shape[1] == p1.size == p2.size,\
+                f"PT.shape[0]={PT.shape[0]}, PT.shape[1]={PT.shape[1]}, p1.size={p1.size}, p2.size={p2.size}"
+            self.p_scalars = False
+        elif isinstance(p1, (float,int)) and isinstance(p2, (float,int)):
+            self.p_scalars = True
+            self.p1p2 = p1*p2
+        else:
+            TypeError("p1 and p2 must be two 1D arrays or two scalar")
+
+
+        self.PT = PT
+        self.p1 = p1
+        self.p2 = p2
+        self.size = PT.shape[0]
+        self.PT_symmetric = PT_symmetric
+
+        self.shape = (self.size,self.size)
+
+        self.PT.sort_indices()
+
+        if not self.PT_symmetric:
+            #store a version of PT as csc for fast access to columns
+            self.PTcsc = self.PT.tocsc()
+        else:
+            self.PTcsc = self.PT
+
+    def __repr__(self):
+
+        if self.PT_symmetric:
+            return f"{self.size}x{self.size} sparse autocovariance matrix with symmetric PT:\n" + \
+                  self.PT.__repr__()
+        else:
+            return f"{self.size}x{self.size} sparse autocovariance matrix with PT:\n" + \
+                  self.PT.__repr__()
+
+    @classmethod
+    def from_T(cls, T, p1=None, p2=None):
+        """Generate autocovariance matrix from transition matrix T as
+
+            S = diag(p1) @ T - p1^T @ p2.
+        
+        Parameters
+        ----------
+        T : NxN scipy csr matrix
+            Transition matrix. T[i,j] is the prob to go from i to j between t1 and t2.
+        p1 : numpy ndarray, optional
+            Probability vector (size = N) at t1. Default is p1[i] = 1/N for all i.
+        p2 : numpy ndarray, optional
+            Probability vector (size = N) at t2. Default is p2 = p1 @ T.
+            
+        Returns
+        -------
+        SparseAutocovMat
+
+        """
+        assert isspmatrix_csr(T)
+        assert T.shape[0] == T.shape[1]
+
+        if p1 is not None:
+            assert isinstance(p1,np.ndarray)
+            assert not isinstance(p1,np.matrix)
+            assert len(p1.shape) == 1
+            assert T.shape[0] == p1.size
+        else:
+            p1 = np.ones(T.shape[0])/T.shape[0]
+
+        if p2 is not None:
+            assert isinstance(p2,np.ndarray)
+            assert not isinstance(p2,np.matrix)
+            assert len(p2.shape) == 1
+            assert T.shape[0] == p2.size
+        else:
+            p2 = p1 @ T
+
+        PT = T.copy()
+        inplace_diag_matmul_csr(PT, p1)
+
+        return cls(PT=PT, p1=p1, p2=p2)
+
+    @classmethod
+    def from_T_forward(cls, T:csr_matrix,
+                       p1:Union[None, NDArray]=None,
+                       p2:Union[None, NDArray]=None):
+        """Generate the forward autocovariance matrix from transition matrix T as
+
+            S = diag(p1) @ T @ diag(1/p2) @ T.T @ diag(p1) - p1.T @ p1.
+
+        
+        Parameters
+        ----------
+        T : NxN scipy csr matrix
+            Transition matrix. T[i,j] is the prob to go from i to j between t1 and t2.
+        p1 : numpy ndarray, optional
+            Probability vector (size = N) at t1. Default is p1[i] = 1/N for all i.
+        p2 : numpy ndarray, optional
+            Probability vector (size = N) at t2. Default is p2 = p1 @ T.
+            
+        Returns
+        -------
+        SparseAutocovMat
+
+        """
+        assert isspmatrix_csr(T)
+        assert T.shape[0] == T.shape[1]
+
+        if p1 is not None:
+            assert isinstance(p1,np.ndarray)
+            assert not isinstance(p1,np.matrix)
+            assert len(p1.shape) == 1
+            assert T.shape[0] == p1.size
+            p1_scalar = False
+        else:
+            p1 = np.ones(T.shape[0])/T.shape[0]
+            p1_scalar = True
+
+        if p2 is not None:
+            assert isinstance(p2,np.ndarray)
+            assert not isinstance(p2,np.matrix)
+            assert len(p2.shape) == 1
+            assert T.shape[0] == p2.size
+        else:
+            p2 = p1 @ T
+
+        p2m1 = p2.copy()
+        p2m1[p2m1==0] = 1 # to avoid product of 0 * inf, which gives nan
+        p2m1 = 1/p2m1
+
+        PT = T.copy()
+        # T @ diag(1/p2)
+        inplace_csr_matmul_diag(PT,p2m1)
+        PT = PT @ T.T
+        inplace_diag_matmul_csr(PT, p1)
+        inplace_csr_matmul_diag(PT, p1)
+
+        if p1_scalar:
+            return cls(PT=PT, p1=p1[0], p2=p1[0], PT_symmetric=True)
+
+        else:
+            return cls(PT=PT, p1=p1, p2=p1, PT_symmetric=True)
+
+    def copy(self):
+
+        return self.__class__(PT=self.PT.copy(),
+                              p1=copy(self.p1),
+                              p2=copy(self.p2),
+                              PT_symmetric=self.PT_symmetric)
+
+    def toarray(self):
+
+        if self.p_scalars:
+            return self.PT.toarray() - np.ones(self.shape)*self.p1p2
+
+        else:
+            return self.PT.toarray() - np.outer(self.p1, self.p2)
+
+
+    def get_submat_sum(self, row_idx, col_idx):
+        """Returns the sum of the elements of the autocov submatrix
+        defined by the indices in idx, i.e. S[row_idx,col_idx].sum().
+            
+        """
+        if self.p_scalars:
+            p0_sum = len(row_idx)*len(col_idx)*self.p1p2
+        else:
+
+            # requires too much memory
+            #p0_sum = np.outer(self.p1[row_idx],self.p2[col_idx]).sum()
+            p0_sum = np.einsum("i,j->i",self.p1[row_idx],self.p2[col_idx]).sum()
+
+        # NOTE: in the non-cython case this might be faster:
+        # PTsum = self.PT._major_index_fancy(row_idx)._minor_index_fancy(col_idx).sum()
+        PTsum = _css.get_submat_sum(self.PT.data, self.PT.indices,
+                                        self.PT.indptr,
+                                        row_idx,
+                                        col_idx)
+        return PTsum - p0_sum
+
+    def get_element(self, i,j):
+        """Returns element (i,j)"""
+        if self.p_scalars:
+            p0 = self.p1p2
+        else:
+            p0 = self.p1[i] * self.p2[j]
+
+        # slightly more fast to directly compute location in csr data
+        k, = np.where(self.PT.indices[self.PT.indptr[i]:self.PT.indptr[i+1]] == j)
+        if len(k) == 0:
+            return -1*p0
+        else:
+            return self.PT.data[self.PT.indptr[i]+k[0]] - p0
+
+    def get_row_idx_sum(self, row, idx):
+        """Return sum of elements at positions given by `idx` in row `row`.
+
+        Parameters
+        ----------
+        row : int
+            Index of row.
+        idx : list
+            List of indices along row `row`.
+
+        Returns
+        -------
+        Autocov[row,idx].sum()
+
+        """
+        if self.p_scalars:
+            p0 = len(idx)*self.p1p2
+        else:
+            p0 = (self.p1[row] * self.p2[idx]).sum()
+
+        # NOTE: in the non-cython case this might be faster:
+        # PTrow = self.PT._major_index_fancy(row)
+        # PTsum = PTrow.data[np.isin(PTrow.indices,idx)].sum()
+        PTsum = _css.get_submat_sum(self.PT.data, self.PT.indices,
+                                        self.PT.indptr,
+                                        np.array([row], dtype=np.int32),
+                                        np.array(idx, dtype=np.int32))
+        return  PTsum - p0
+
+    def get_col_idx_sum(self, col, idx):
+        """Return sum of elements at positions given by `idx` in col `col`.
+        
+        Parameters
+        ----------
+        col : int
+            Index of col.
+        idx : list
+            List of indices along col `col`.
+
+        Returns
+        -------
+        Autocov[idx,col].sum()
+
+        """
+        if self.p_scalars:
+            p0 = len(idx)*self.p1p2
+        else:
+            p0 = (self.p1[idx] * self.p2[col]).sum()
+
+
+        # NOTE: in the non-cython case this might be faster:
+        # PTcol = self.PTcsc._major_index_fancy(col)
+        # PTsum = PTcol.data[np.isin(PTcol.indices,idx)].sum()
+        PTsum = _css.get_submat_sum(self.PTcsc.data, self.PTcsc.indices,
+                                        self.PTcsc.indptr,
+                                        np.array([col], dtype=np.int32),
+                                        np.array(idx, dtype=np.int32))
+        return  PTsum - p0
+
+
+
+    def aggregate(self, idx_list):
+        """Returns a new SparseAutocovMat where elements of
+            the original mat have been aggregated according to 
+            idx_list.
+        
+        Parameters
+        ----------
+        idx_list : list of lists of ints
+            idx_list[i] and idx_list[j] contains the list of 
+            row indices and col_indices to be aggregated to form S[i,j].
+
+        Returns
+        -------
+        new aggregated SparseAutocovMat
+
+        """
+        # convert idx_list to a single array of indices and an array of
+        # pointers to start/stops for each cluster.
+        idxs_array = np.array([i for idx in idx_list for i in idx], dtype=np.int32)
+        idxptr = np.cumsum([0]+[len(idx) for idx in idx_list], dtype=np.int32)
+
+
+
+        new_size = idxptr.size-1
+
+        # choose the fastest version
+        if new_size**2 < self.PT.data.size:
+            PTdata, PTrows, PTcols, new_size = _css.aggregate_csr_mat(self.PT.data,
+                                                                    self.PT.indices,
+                                                                    self.PT.indptr,
+                                                                    idxs_array,
+                                                                    idxptr)
+        else:
+            PTdata, PTrows, PTcols, new_size = _css.aggregate_csr_mat_2(self.PT.data,
+                                                                    self.PT.indices,
+                                                                    self.PT.indptr,
+                                                                    idxs_array,
+                                                                    idxptr)
+
+        newPT = coo_matrix((PTdata,(PTrows,PTcols)), shape=(new_size,new_size))
+
+        # the aggregated S will not have scalars p
+        if self.p_scalars:
+            oldp1 = np.ones(self.shape[0])/self.shape[0]
+            oldp2 = oldp1
+        else:
+            oldp1 = self.p1
+            oldp2 = self.p2
+
+        newp1 = np.zeros(new_size, dtype=np.float64)
+        newp2 = np.zeros(new_size, dtype=np.float64)
+        for k, idx in enumerate(idx_list):
+            newp1[k] = oldp1[idx].sum()
+            newp2[k] = oldp2[idx].sum()
+
+        #normalize p1 and p2 for rounding errors
+        newp1 = newp1/newp1.sum()
+        newp2 = newp2/newp2.sum()
+
+        return self.__class__(PT=newPT.tocsr(),
+                              p1=newp1, p2=newp2,
+                              PT_symmetric=self.PT_symmetric)
+
+
+    def is_all_zeros(self):
+        """Returns True of all values are equal to zero.
+        checks only nonzero values of self.PT 
+        """
+        if self.p_scalars:
+            for row in range(self.size):
+                for k in range(self.PT.indptr[row],self.PT.indptr[row+1]):
+                    col = self.PT.indices[k]
+                    if not np.allclose(self.PT.data[k], self.p1p2):
+                        return False
+        else:
+            for row in range(self.size):
+                for k in range(self.PT.indptr[row],self.PT.indptr[row+1]):
+                    col = self.PT.indices[k]
+                    if not np.allclose(self.PT.data[k], self.p1[row]*self.p2[col]):
+                        return False
+
+        return True
+
+    def _compute_delta_S_moveto(self, k, idx):
+        """Return the gain in stability obtained by moving node
+        k into the community defined by index list in idx.
+            
+        """
+        # NOTE: in the non-cython case this might be faster:
+        # return self._S.get_row_idx_sum(k,idx) \
+        #             + self._S.get_col_idx_sum(k,idx) \
+        #             + self._S.get_element(k,k)
+        if self.p_scalars:
+            PTsum = _css.compute_delta_PT_moveto(self.PT.data,
+                                                    self.PT.indices,
+                                                    self.PT.indptr,
+                                                    self.PTcsc.data,
+                                                    self.PTcsc.indices,
+                                                    self.PTcsc.indptr,
+                                                    k,
+                                                    idx)
+
+            return PTsum - (2*len(idx)+1)*self.p1p2
+
+        else:
+            return _css.compute_delta_S_moveto(self.PT.data,
+                                                    self.PT.indices,
+                                                    self.PT.indptr,
+                                                    self.PTcsc.data,
+                                                    self.PTcsc.indices,
+                                                    self.PTcsc.indptr,
+                                                    k,
+                                                    idx,
+                                                    self.p1,
+                                                    self.p2)
+
+
+    def _compute_delta_S_moveout(self, k, idx):
+        """Return the gain in stability obtained by moving node
+        k outside the community defined by index list in idx.
+            
+        """
+        # NOTE: in the non-cython case this might be faster:
+        # return - self._S.get_row_idx_sum(k,idx) \
+        #             - self._S.get_col_idx_sum(k,idx) \
+        #             + self._S.get_element(k,k)
+        if self.p_scalars:
+            PTsum = _css.compute_delta_PT_moveout(self.PT.data,
+                                                    self.PT.indices,
+                                                    self.PT.indptr,
+                                                    self.PTcsc.data,
+                                                    self.PTcsc.indices,
+                                                    self.PTcsc.indptr,
+                                                    k,
+                                                    np.array(idx, dtype=np.int32))
+
+            return PTsum + (2*len(idx)-1)*self.p1p2
+
+        else:
+            return _css.compute_delta_S_moveout(self.PT.data,
+                                                self.PT.indices,
+                                                self.PT.indptr,
+                                                self.PTcsc.data,
+                                                self.PTcsc.indices,
+                                                self.PTcsc.indptr,
+                                                k,
+                                                np.array(idx, dtype=np.int32),
+                                                self.p1,
+                                                self.p2)
+
+
+@timing
+def sparse_outer(p, use_mkl=True, triu=True, verbose=False, log_message=""):
+    """Computes the sparse outer product p.T @ p
+
+    Parameters
+    ----------
+    p : (1,N) csr sparse matrix
+        Sparse array.
+    use_mkl : bool
+        Whether to use INTEL MKL for multithreading.
+    triu : bool
+        Whether to return an upper triangular matrix. Usually slower but 
+        output requires less memory.
+
+    Returns
+    -------
+    O : (N,N) csr sparse matrix.
+    
+    If USE_SPARSE_DOT_MKL and use_mkl returns a matrix with only the upper triangle filled.
+
+    """
+    assert isspmatrix_csr(p)
+    assert p.shape[0] == 1
+
+    p.eliminate_zeros()
+    p.sort_indices()
+
+    if USE_SPARSE_DOT_MKL and use_mkl:
+        if triu:
+            Odata = gram_matrix_mkl(p.data.reshape(1,p.data.size))[np.triu_indices(p.data.size)]
+        else:
+            Odata = gram_matrix_mkl(p.data.reshape(1,p.data.size)).reshape(p.data.size**2,1).squeeze()
+    elif triu:
+        Odata = np.outer(p.data,p.data)[np.triu_indices(p.data.size)]
+    else:
+        Odata = np.outer(p.data,p.data).reshape(p.data.size**2,1).squeeze()
+
+    if triu:
+        indices_list = [p.indices[p.indices >= r] for r in p.indices]
+        row_len = iter([i.size for i in indices_list])
+        num_per_row = [next(row_len) if r in p.indices else 0 for r in range(p.shape[1])]
+    else:
+        indices_list = [p.indices]*p.indices.size
+        num_per_row = [p.indices.size if r in p.indices else 0 for r in range(p.shape[1])]
+
+    Oindices = np.concatenate(indices_list)
+
+    Oindptr = np.cumsum([0] + num_per_row)
+
+    return csr_matrix((Odata, Oindices, Oindptr), shape=(p.shape[1], p.shape[1]))
+
+
+
+@timing
+def sparse_matmul(A, B, verbose=False, log_message=""):
+    """Sparse matrix multiplication.
+    Uses sparse_dot_mkl if available, otherwise scipy sparse
+    """
+    if USE_SPARSE_DOT_MKL:
+        return dot_product_mkl(A,B)
+    else:
+        return A @ B
+
+@timing
+def sparse_gram_matrix(A, transpose, verbose=False, log_message=""):
+    """If transpose is True, returns A @ A.T
+    else, returns A.T @ A
+        
+    If USE_SPARSE_DOT_MKL returns a matrix with only the upper triangle filled.
+        
+    """
+    if USE_SPARSE_DOT_MKL:
+        return gram_matrix_mkl(A, transpose=transpose)
+    elif transpose:
+        return A @ A.T
+    else:
+        return A.T @ A

--- a/src/tempnet/temporal_network.py
+++ b/src/tempnet/temporal_network.py
@@ -24,6 +24,7 @@ import os
 import pickle
 import time
 from functools import partial
+from xxlimited import new
 
 import numpy as np
 import pandas as pd
@@ -49,7 +50,6 @@ from .logger import get_logger
 
 # get the logger
 logger = get_logger()
-
 class ContTempNetwork:
     """Continuous time temporal network
     
@@ -117,6 +117,7 @@ class ContTempNetwork:
                  events_table=None,
                  **kwargs):
 
+        #check that the mandatory columns have the same size if events_table is not given
         if events_table is None:
             assert len(source_nodes) == len(target_nodes) == \
                    len(starting_times) == len(ending_times)
@@ -127,6 +128,7 @@ class ContTempNetwork:
                 all_nodes = set()
                 all_nodes.update(source_nodes)
                 all_nodes.update(target_nodes)
+            
                 self.label_to_node_dict = {l : n for n, l in enumerate(sorted(all_nodes))}
                 self.node_to_label_dict = {n : l for l, n in self.label_to_node_dict.items()}
 
@@ -139,8 +141,7 @@ class ContTempNetwork:
                                                   "target_nodes" : target_nodes,
                                                   "starting_times" : starting_times,
                                                   "ending_times" : ending_times}
-            columns=["source_nodes","target_nodes",
-                                             "starting_times","ending_times"]
+            columns=self._ESSENTIAL
 
             if extra_attrs is not None:
                 assert isinstance(extra_attrs, dict)
@@ -210,7 +211,7 @@ class ContTempNetwork:
         self.events_table["durations"] = self.events_table.ending_times - \
                             self.events_table.starting_times
 
-        # to record compute times
+        # to record compute times (CHECK)
         self._compute_times = {}
 
         self._overlapping_events_merged = False
@@ -1075,17 +1076,15 @@ class ContTempNetwork:
         mask = np.logical_and(self.events_table.starting_times < end_time,
                               self.events_table.ending_times > start_time)
 
-        # loop on events
-        data = []
-        cols = []
-        rows = []
-        for ev in self.events_table.loc[mask].itertuples():
-            data.append(min(ev.ending_times, end_time) - max(ev.starting_times, start_time))
-            rows.append(ev.source_nodes)
-            cols.append(ev.target_nodes)
+        ev = self.events_table.loc[mask]
+            # Vectorized overlap calculation
+        data = (np.minimum(ev.ending_times.values, end_time) -
+                    np.maximum(ev.starting_times.values, start_time))
 
-        A = coo_matrix((data, (rows,cols)),
-                       shape=(self.num_nodes, self.num_nodes))
+        A = coo_matrix(
+                (data, (ev.source_nodes.values, ev.target_nodes.values)),
+                shape=(self.num_nodes, self.num_nodes)
+            )
 
         return A + A.T
 

--- a/src/tempnet/temporal_network.py
+++ b/src/tempnet/temporal_network.py
@@ -1,7 +1,7 @@
 """#
-# flow stability
+# Temporal networks
 #
-# Copyright (C) 2021 Alexandre Bovet <alexandre.bovet@maths.ox.ac.uk>
+# Copyright (C) 2026 Alexandre Bovet research group <alexandre.bovet@uzh.ch>
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of the GNU Lesser General Public License as published by the Free


### PR DESCRIPTION
Here, I added two test cases to verify that the code is correct. I will update it to a pytest later. 

Moreover, I used vectorized calculations instead of a for loop to speed up the computation. The output is still in the same COO format. 

Previous calculation on the mice dataset ( with 437 nodes and 5751692 events): 14 s ± 2.62 s per loop (mean ± std. dev. of 7 runs, 1 loop each)
New calculation on the mice dataset ( with 437 nodes and 5751692 events): 1.04 s ± 225 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

Speedup: 14x

Added the helpers from the flow-stability project; I'm not sure if they'll be needed. But we can remove it later:)